### PR TITLE
League\Container\ContainerAwareTrait::getContainer() throws exceptions now

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -11,6 +11,7 @@ use Robo\Common\IO;
 use Robo\Exception\TaskExitException;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
+use League\Container\Exception\ContainerException;
 use Consolidation\Config\Util\EnvConfig;
 
 class Runner implements ContainerAwareInterface
@@ -204,7 +205,9 @@ class Runner implements ContainerAwareInterface
         $this->setOutput($output);
 
         // If we were not provided a container, then create one
-        if (!$this->getContainer()) {
+        try {
+            $this->getContainer();
+        } catch (ContainerException $e) {
             $configFiles = $this->getConfigFilePaths($this->configFilename);
             $config = Robo::createConfiguration($configFiles);
             if ($this->envConfigPrefix) {


### PR DESCRIPTION
>  League Container changed a bunch of method names from 2.x->3.x, but must have changed something more significant as well because tests are failing with errors such as No container implementation has been set.. We need to figure out how to get tests passing and finish the upgrade

`No container implementation has been set` is an exception that [League\Container\ContainerAwareTrait::getContainer()](https://github.com/thephpleague/container/blob/3.3.1/src/ContainerAwareTrait.php#L34-L46) now throws if a container has not yet been set.  The [2.x version of this method](https://github.com/thephpleague/container/blob/2.4.1/src/ContainerAwareTrait.php#L25-L33) did not throw exceptions.

I verified locally that these changes resolve the `No container implementation has been set` errors although there are still other test failures.